### PR TITLE
Build before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha ./test",
     "build": "babel index.js -d dist",
-    "install": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will move the build step in `prepare` (before packing & publishing) instead of `install`